### PR TITLE
Add basic database migrations

### DIFF
--- a/migrations/000-dummy.sql
+++ b/migrations/000-dummy.sql
@@ -1,0 +1,2 @@
+-- Expect this migration to be removed after installing and using something like golang-migrate
+SELECT 1+1;

--- a/test/postgres.go
+++ b/test/postgres.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"path/filepath"
 	"time"
 
 	"github.com/testcontainers/testcontainers-go"
@@ -12,13 +13,20 @@ import (
 )
 
 func StartPostgres(ctx context.Context) (err error, conn string, done func()) {
+	migrationFiles, err := filepath.Glob("../migrations/*.sql")
+	if err != nil {
+		return fmt.Errorf("failed to list database migrations: %w", err), "", func() {}
+	}
+
 	postgresContainer, err := postgres.Run(ctx,
 		"docker.io/postgres:16-alpine",
 		postgres.WithDatabase("incident_reviewer"),
+		postgres.WithInitScripts(migrationFiles...),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(5*time.Second)),
+				WithStartupTimeout(5*time.Second),
+		),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to start postgres: %w", err), "", nil


### PR DESCRIPTION
This is preparing to use something like golang-migrate which keeps the
migrations as sql files and then orchestrates around it.

Probably would be best to actually run the migration tool in the
startup instead of doing this, though, to exercise the tool.
