### PR TITLE
Add missing fields to the report and get linting in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [ $default-branch ]
   pull_request: {}
 
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -24,3 +28,17 @@ jobs:
       - run: script/cibuild
         env:
           BROWSER: ${{ matrix.browser }}
+          CI: true
+
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.62.2  # golangci-lint version

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,53 @@
+linters:
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable: []
+
+linters-settings:
+  gocritic:
+    enabled-checks:
+      # https://go-critic.com/overview.html#ruleguard
+      - ruleguard
+
+    # Settings passed to gocritic.
+    # The settings key is the name of a supported gocritic checker.
+    # The list of supported checkers can be find in https://go-critic.com/overview.
+    settings:
+      ruleguard:
+        # Enable debug to identify which 'Where' condition was rejected.
+        # The value of the parameter is the name of a function in a ruleguard file.
+        #
+        # When a rule is evaluated:
+        # If:
+        #   The Match() clause is accepted; and
+        #   One of the conditions in the Where() clause is rejected,
+        # Then:
+        #   ruleguard prints the specific Where() condition that was rejected.
+        #
+        # The option is passed to the ruleguard 'debug-group' argument.
+        # Default: ""
+        debug: ''
+        # Determines the behavior when an error occurs while parsing ruleguard files.
+        # If flag is not set, log error and skip rule files that contain an error.
+        # If flag is set, the value must be a comma-separated list of error conditions.
+        # - 'all':    fail on all errors.
+        # - 'import': ruleguard rule imports a package that cannot be found.
+        # - 'dsl':    gorule file does not comply with the ruleguard DSL.
+        # Default: ""
+        failOn: ""
+        # Comma-separated list of file paths containing ruleguard rules.
+        # If a path is relative, it is relative to the directory where the golangci-lint command is executed.
+        # The special '${configDir}' variable is substituted with the absolute directory containing the golangci config file.
+        # Glob patterns such as 'rules-*.go' may be specified.
+        # Default: ""
+        rules: '${configDir}/ruleguard/rules-*.go'
+        # Comma-separated list of disabled groups or skip empty to enable everything.
+        # Tags can be defined with # character prefix.
+        # Default: ""
+        disable: ""
+
+issues:
+  # Maximum issues count per one linter.
+  # Set to 0 to disable.
+  # Default: 50
+  max-issues-per-linter: 0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 golang 1.23.3
 air 1.61.0
+golangci-lint 1.62.2

--- a/cmd/incident-reviewer/main.go
+++ b/cmd/incident-reviewer/main.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/gaqzi/incident-reviewer/internal/app"
@@ -20,13 +21,13 @@ func main() {
 
 	slog.Info("server started", "addr", "http://"+server.Config.Addr)
 
-	shutdown := make(chan os.Signal)
-	signal.Notify(shutdown, os.Interrupt, os.Kill)
+	shutdown := make(chan os.Signal, 2)
+	signal.Notify(shutdown, os.Interrupt, syscall.SIGTERM)
 
 	for {
 		sig := <-shutdown
 		switch sig {
-		case os.Interrupt, os.Kill:
+		case os.Interrupt, syscall.SIGTERM:
 			cancel()
 			shutCtx, shutCancel := context.WithTimeout(context.Background(), 10*time.Second)
 

--- a/cmd/local-dev-dependencies/main.go
+++ b/cmd/local-dev-dependencies/main.go
@@ -48,6 +48,9 @@ func main() {
 	ctx, cancelCtx = context.WithCancel(context.Background())
 	daemon.AddCommand(daemon.StringFlag(signal, "quit"), syscall.SIGQUIT, termHandlerCreator(cancelCtx))
 	daemon.AddCommand(daemon.StringFlag(signal, "stop"), syscall.SIGTERM, termHandlerCreator(cancelCtx))
+	if err := os.MkdirAll("tmp", 0755); err != nil {
+		log.Fatalln(err.Error())
+	}
 
 	cntxt := &daemon.Context{
 		PidFileName: "tmp/local-dev-dependencies.pid",

--- a/internal/reviewing/http/handler.go
+++ b/internal/reviewing/http/handler.go
@@ -62,8 +62,8 @@ type ReviewBasic struct {
 	Description string `form:"description"`
 	Impact      string `form:"impact"`
 
-	UpdatedAt time.Time `form:"updated_at"`
-	CreatedAt time.Time `form:"created_at"`
+	UpdatedAt time.Time
+	CreatedAt time.Time
 }
 
 func (a *App) Create(w http.ResponseWriter, r *http.Request) {

--- a/internal/reviewing/http/templates/_review-fields.html
+++ b/internal/reviewing/http/templates/_review-fields.html
@@ -24,5 +24,23 @@
             <textarea name="impact" required>{{ .Impact }}</textarea>
         </label>
     </li>
+    <li>
+        <label>
+            Where:
+            <textarea name="where" required>{{ .Where }}</textarea>
+        </label>
+    </li>
+    <li>
+        <label>
+            Report <dfn title="The closest direct cause for the incident, often called the root cause">proximal cause</dfn>:
+            <textarea name="reportProximalCause" required>{{ .ReportProximalCause }}</textarea>
+        </label>
+    </li>
+    <li>
+        <label>
+            Report <dfn title="The change that lead to the proximal cause which lead to the incident">trigger</dfn>:
+            <textarea name="reportTrigger" required>{{ .ReportTrigger }}</textarea>
+        </label>
+    </li>
 </ul>
 {{ end }}

--- a/internal/reviewing/http/templates/show.html
+++ b/internal/reviewing/http/templates/show.html
@@ -7,6 +7,12 @@
 
             <p class="impact">{{ .Impact }}</p>
 
+            <p class="where">{{ .Where }}</p>
+
+            <p class="reportProximalCause">{{ .ReportProximalCause }}</p>
+
+            <p class="reportTrigger">{{ .ReportTrigger }}</p>
+
             <ul>
                 <li><time class="createdAt" datetime="{{ .CreatedAt.Format "2006-01-02T15:04:05.999999999Z07:00" }}">{{ .CreatedAt }}</time></li>
                 <li><time class="updatedAt" datetime="{{ .UpdatedAt.Format "2006-01-02T15:04:05.999999999Z07:00" }}">{{ .UpdatedAt }}</time></li>

--- a/internal/reviewing/review.go
+++ b/internal/reviewing/review.go
@@ -3,11 +3,14 @@ package reviewing
 import "time"
 
 type Review struct {
-	ID          int64
-	URL         string `validate:"required,http_url"`
-	Title       string `validate:"required"`
-	Description string `validate:"required"`
-	Impact      string `validate:"required"`
+	ID                  int64
+	URL                 string `validate:"required,http_url"`
+	Title               string `validate:"required"`
+	Description         string `validate:"required"`
+	Impact              string `validate:"required"`
+	Where               string `validate:"required"`
+	ReportProximalCause string `validate:"required"`
+	ReportTrigger       string `validate:"required"`
 
 	CreatedAt time.Time
 	UpdatedAt time.Time

--- a/internal/reviewing/storage/storage_test.go
+++ b/internal/reviewing/storage/storage_test.go
@@ -19,10 +19,13 @@ import (
 func StorageTest(t *testing.T, ctx context.Context, storeFactory func() reviewing.Storage) {
 	validReview := func(modify ...func(r *reviewing.Review)) reviewing.Review {
 		review := reviewing.Review{
-			URL:         "https://example.com/reviews/1",
-			Title:       "Something",
-			Description: "At the bottom of the sea",
-			Impact:      "did a bunch of things",
+			URL:                 "https://example.com/reviews/1",
+			Title:               "Something",
+			Description:         "At the bottom of the sea",
+			Impact:              "did a bunch of things",
+			Where:               "At land",
+			ReportProximalCause: "Broken",
+			ReportTrigger:       "Special operation",
 		}
 
 		for _, mod := range modify {
@@ -45,13 +48,16 @@ func StorageTest(t *testing.T, ctx context.Context, storeFactory func() reviewin
 			require.Equal(
 				t,
 				reviewing.Review{
-					ID:          actual.ID,
-					URL:         review.URL,
-					Title:       review.Title,
-					Description: review.Description,
-					Impact:      review.Impact,
-					CreatedAt:   actual.CreatedAt,
-					UpdatedAt:   actual.UpdatedAt,
+					ID:                  actual.ID,
+					URL:                 review.URL,
+					Title:               review.Title,
+					Description:         review.Description,
+					Impact:              review.Impact,
+					Where:               review.Where,
+					ReportProximalCause: review.ReportProximalCause,
+					ReportTrigger:       review.ReportTrigger,
+					CreatedAt:           actual.CreatedAt,
+					UpdatedAt:           actual.UpdatedAt,
 				},
 				actual,
 				"expected to have saved and set the ID which is used as primary key",
@@ -144,6 +150,7 @@ func StorageTest(t *testing.T, ctx context.Context, storeFactory func() reviewin
 				r.URL = "https://example.com/reviews/2"
 				r.Title = "Another review"
 			}))
+			require.NoError(t, err)
 
 			actual, err := store.All(ctx)
 			require.NoError(t, err)

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -58,8 +58,8 @@ go mod download -x
 GOOSE_VERSION=$(awk '/pressly\/goose\/v3/ {print $2}' go.mod)
 go install -tags='no_clickhouse no_libsql no_mssql no_mysql no_vertica no_xflag no_ydb' "github.com/pressly/goose/v3/cmd/goose@$GOOSE_VERSION"
 
-## Install playwright dependencies
-go run ./cmd/local-dev-dependencies/ playwright
+## Install playwright dependencies, runs in the background
+go run ./cmd/local-dev-dependencies/ playwright &
 
 function get-container() {
   local variable_name="$1"
@@ -77,8 +77,11 @@ function get-container() {
   fi
 }
 
-## Download required testcontainer dependency containers
-get-container "PostgresContainer" "test/postgres.go"
+## Download required testcontainer dependency containers, runs in background
+get-container "PostgresContainer" "test/postgres.go" &
+
+## Wait for all background jobs to finish
+wait
 
 ## Always finish with go mod tidy
 # In case we get something nasty when installing everything it'll try and sort it out,

--- a/script/sync-golangci-lint-version
+++ b/script/sync-golangci-lint-version
@@ -5,14 +5,15 @@
 : ${VERSION:=$1}
 
 if [ -z "$VERSION" ]; then
-  GO_VERSION="latest"
+  GOLANGCI_LINT_VERSION="latest"
 fi
 
 ## Set to the specified version, latest if none specified on the cli
-asdf install golang "$GO_VERSION"
-asdf local golang "$GO_VERSION"
-GO_VERSION=$(grep "golang " .tool-versions | cut -d' ' -f 2)
+asdf install golangci-lint "$GOLANGCI_LINT_VERSION"
+asdf local golangci-lint "$GOLANGCI_LINT_VERSION"
+GOLANGCI_LINT_VERSION=$(grep golangci-lint .tool-versions | cut -d' ' -f 2)
 
 ## Update go.mod to require the specified version,
 ## which we then rely on in the workflow for CI
-sed -I '' -E "s/^go (.*)$/go $GO_VERSION/" go.mod
+MATCHING_COMMENT="# golangci-lint version"
+sed -I '' -E "s/(version:) v(.*)(  $MATCHING_COMMENT)/\1 v$GOLANGCI_LINT_VERSION\3/" .github/workflows/ci.yml

--- a/script/test
+++ b/script/test
@@ -1,3 +1,9 @@
 #!/bin/bash
 
+## Run golangci-lint if not on CI
+if [ "$CI" != 'true' ] ; then
+  golangci-lint run || exit 1
+fi
+
+## Run the go tests
 exec go test -race ./...

--- a/script/update
+++ b/script/update
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+## Stop local-dev-dependencies if it's running
+go run ./cmd/local-dev-dependencies stop
+
 ## Clean out tmp since we keep a bunch of files there
 rm -rf tmp/
 

--- a/test/reviewing_test.go
+++ b/test/reviewing_test.go
@@ -67,9 +67,12 @@ func TestReviewing(t *testing.T) {
 
 		form := page.Locator(".new form")
 		require.NoError(t, form.Locator(`[name="url"]`).Fill("https://example.com/incident/1"))
-		require.NoError(t, form.Locator(`[name="title"]`).Fill("Undersea cable broken"))
-		require.NoError(t, form.Locator(`[name="description"]`).Fill("A Chinese vessel dragged it's anchor across the seabed for 100km"))
+		require.NoError(t, form.Locator(`[name="title"]`).Fill("Higher than normal latency due undersea cable breaking"))
+		require.NoError(t, form.Locator(`[name="description"]`).Fill("Customers in Latvia started seeing higher latency due to an undersea cable breaking and getting routed through other cables"))
 		require.NoError(t, form.Locator(`[name="impact"]`).Fill("5% of all customers in Latvia seeing higher than average latency, no impact on orders"))
+		require.NoError(t, form.Locator(`[name="where"]`).Fill("Latvia"))
+		require.NoError(t, form.Locator(`[name="reportProximalCause"]`).Fill("A broken undersea cabel"))
+		require.NoError(t, form.Locator(`[name="reportTrigger"]`).Fill("A Chinese vessel dragged it's anchor across the seabed for 100km"))
 		require.NoError(t, form.Locator(`[type="submit"]`).Click())
 
 		require.NoError(
@@ -80,7 +83,7 @@ func TestReviewing(t *testing.T) {
 		require.NoError(
 			t,
 			assert.Locator(page.Locator(".new .notice a")).
-				ToHaveAttribute("href", "/reviews/1-"+slug.Make("Undersea cable broken")),
+				ToHaveAttribute("href", "/reviews/1-"+slug.Make("Higher than normal latency due undersea cable breaking")),
 			"expected to have slugified the URL correctly for the notice",
 		)
 
@@ -92,16 +95,21 @@ func TestReviewing(t *testing.T) {
 		require.NoError(
 			t,
 			assert.Locator(page.Locator(".listing ul li a")).
-				ToHaveAttribute("href", "/reviews/1-"+slug.Make("Undersea cable broken")),
+				ToHaveAttribute("href", "/reviews/1-"+slug.Make("Higher than normal latency due undersea cable breaking")),
 			"expected to have slugified the URL correctly in the listing",
 		)
 
-		// Time to click into it and edit
+		// Time to click into it and verify the fields
 		require.NoError(t, page.Locator(".new .notice a").Click())
 		createdAt, err := page.Locator(".details .createdAt").GetAttribute("datetime")
 		require.NoError(t, err, "failed to get createdAt")
 		updatedAt, err := page.Locator(".details .updatedAt").GetAttribute("datetime")
 		require.NoError(t, err, "failed to get updatedAt")
+		require.NoError(t, assert.Locator(page.Locator(".details .where")).ToContainText("Latvia"))
+		require.NoError(t, assert.Locator(page.Locator(".details .reportProximalCause")).ToContainText("A broken undersea cabel"))
+		require.NoError(t, assert.Locator(page.Locator(".details .reportTrigger")).ToContainText("A Chinese vessel dragged it's anchor across the seabed for 100km"))
+
+		// Time to click in and edit a field
 		require.NoError(t, page.Locator(`.details form button[type="submit"]`).Click())
 
 		require.NoError(t, page.Locator(`.details form [name="title"]`).Fill("Broken cable undersea"))


### PR DESCRIPTION
- **Stop the local-dev-dependencies when updating**
  So we don't get a zombie when the tmp/ folder gets deleted.
  

- **Run the big downloading commands as bg jobs**
  Because most of the time I'm not saturating my internet connection so
  if they ran in parallel, I'd benefit from it.
  
  Let's see how well this works in practice. :)
  

- **Stop parsing updated/created at from the form**
  They're not supposed to be changed so don't even make them available
  even if they will be when using the model.
  

- **Add missing fields for the report**
  To summarize the incident based on the remote report these fields
  should be available. Then for more info you can click through to get
  there.
  

- **Create the tmp folder if it doesn't exist**
  

- **Install golangci-lint**
  And also fix all the linting problems that came with the standard set.
  