### PR TITLE
Lint to not pass domain objects into templates

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,8 @@
 linters:
   # Enable specific linter
   # https://golangci-lint.run/usage/linters/#enabled-by-default
-  enable: []
+  enable:
+    - gocritic
 
 linters-settings:
   gocritic:

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/playwright-community/playwright-go v0.4901.0
 	github.com/pressly/goose/v3 v3.23.1
+	github.com/quasilyte/go-ruleguard/dsl v0.3.22
 	github.com/sevlyar/go-daemon v0.1.6
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.34.0

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,8 @@ github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/pressly/goose/v3 v3.23.1 h1:bwjOXvep4HtuiiIqtrXmCkQu0IW9O9JAqA6UQNY9ntk=
 github.com/pressly/goose/v3 v3.23.1/go.mod h1:0oK0zcK7cmNqJSVwMIOiUUW0ox2nDIz+UfPMSOaw2zY=
+github.com/quasilyte/go-ruleguard/dsl v0.3.22 h1:wd8zkOhSNr+I+8Qeciml08ivDt1pSXe60+5DqOpCjPE=
+github.com/quasilyte/go-ruleguard/dsl v0.3.22/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=

--- a/internal/reviewing/http/handler.go
+++ b/internal/reviewing/http/handler.go
@@ -118,7 +118,7 @@ func (a *App) renderIndex(h *htmx.Handler, r *http.Request, data map[string]any)
 			slog.Error("failed to fetch all reviews", "error", err)
 		}
 		cancel()
-		data["Reviews"] = convertToHttpObject(reviews)
+		data["Reviews"] = convertToHttpObjects(reviews)
 	}
 
 	page := htmx.NewComponent("templates/index.html").
@@ -166,7 +166,7 @@ func (a *App) Show(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := map[string]any{
-		"Review": review,
+		"Review": convertToHttpObject(review),
 	}
 
 	page := htmx.NewComponent("templates/show.html").
@@ -208,7 +208,7 @@ func (a *App) Edit(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := map[string]any{
-		"Review": review,
+		"Review": convertToHttpObject(review),
 	}
 
 	page := htmx.NewComponent("templates/edit.html").
@@ -284,26 +284,30 @@ func baseContent() htmx.RenderableComponent {
 	return htmx.NewComponent("templates/base.html").FS(templates)
 }
 
-func convertToHttpObject(rs []reviewing.Review) []ReviewBasic {
+func convertToHttpObjects(rs []reviewing.Review) []ReviewBasic {
 	ret := make([]ReviewBasic, 0, len(rs))
 
 	for _, r := range rs {
-		ret = append(ret, ReviewBasic{
-			ID:                  r.ID,
-			URL:                 r.URL,
-			Title:               r.Title,
-			Description:         r.Description,
-			Impact:              r.Impact,
-			Where:               r.Where,
-			ReportProximalCause: r.ReportProximalCause,
-			ReportTrigger:       r.ReportTrigger,
-
-			CreatedAt: r.CreatedAt,
-			UpdatedAt: r.UpdatedAt,
-		})
+		ret = append(ret, convertToHttpObject(r))
 	}
 
 	return ret
+}
+
+func convertToHttpObject(r reviewing.Review) ReviewBasic {
+	return ReviewBasic{
+		ID:                  r.ID,
+		URL:                 r.URL,
+		Title:               r.Title,
+		Description:         r.Description,
+		Impact:              r.Impact,
+		Where:               r.Where,
+		ReportProximalCause: r.ReportProximalCause,
+		ReportTrigger:       r.ReportTrigger,
+
+		CreatedAt: r.CreatedAt,
+		UpdatedAt: r.UpdatedAt,
+	}
 }
 
 // assignFromHttpObject takes all values from rb and assigns them to r.

--- a/ruleguard/rules-dont-pass-domain-objects-to-templates.go
+++ b/ruleguard/rules-dont-pass-domain-objects-to-templates.go
@@ -1,0 +1,24 @@
+//go:build ruleguard
+// +build ruleguard
+
+package ruleguard
+
+import (
+	"github.com/quasilyte/go-ruleguard/dsl"
+)
+
+func execContext(m dsl.Matcher) {
+	m.Import("github.com/gaqzi/incident-reviewer/internal/reviewing")
+
+	// Extremely simplistic rule: if we ever assign the reviewing.Review
+	// object into a map directly we're doing it wrong. It should ideally
+	// be _any_ object from reviewing.* and only in the reviewing.http
+	// package, but I don't know enough about ruleguard to handle that yet.
+	//
+	// TODO: make this matcher handle the above.
+	//
+	// To work on this use ruleguard directly: ruleguard -rules ruleguard/rules-dont-pass-domain-objects-to-templates.go internal/reviewing/http/handler.go
+	m.Match(`map[string]any{$*_, $key: $val, $*_}`).
+		Where(m["val"].Type.Is(`reviewing.Review`)).
+		Report(`passing reviewing.Review into a template's SetData map`)
+}


### PR DESCRIPTION
Because we are supposed to use a specific object for dealing with the
outermost layer. Even if they today are merely clones of each other.
