### PR TITLE
make contributing cause have coordination in service and not repo

### DIFF
--- a/internal/app/reviewer.go
+++ b/internal/app/reviewer.go
@@ -74,11 +74,12 @@ func Start(ctx context.Context, cfg Config) (*Server, error) {
 
 	causeStore := normStore.NewContributingCauseMemoryStore()
 	causeService := normalized.NewContributingCauseService(causeStore)
-	_, err = causeService.Save(ctx, normalized.ContributingCause{
-		Name:        "Third party outage",
-		Description: "In case a third party experienced issues/outage and it leads to an incident on our side.\nThings like third party changing configuration and it leading to issues on our side also qualifies",
-		Category:    "Design",
-	})
+
+	cause := normalized.NewContributingCause()
+	cause.Name = "Third party outage"
+	cause.Description = "In case a third party experienced issues/outage and it leads to an incident on our side.\nThings like third party changing configuration and it leading to issues on our side also qualifies"
+	cause.Category = "Design"
+	_, err = causeService.Save(ctx, cause)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add default contributing causes: %w", err)
 	}

--- a/internal/app/reviewer.go
+++ b/internal/app/reviewer.go
@@ -72,9 +72,7 @@ func Start(ctx context.Context, cfg Config) (*Server, error) {
 
 	httpassets.PublicAssets(r)
 
-	causeStore := normStore.NewContributingCauseMemoryStore()
-	causeService := normalized.NewContributingCauseService(causeStore)
-
+	causeService := normalized.NewContributingCauseService(normStore.NewContributingCauseMemoryStore())
 	cause := normalized.NewContributingCause()
 	cause.Name = "Third party outage"
 	cause.Description = "In case a third party experienced issues/outage and it leads to an incident on our side.\nThings like third party changing configuration and it leading to issues on our side also qualifies"
@@ -85,7 +83,7 @@ func Start(ctx context.Context, cfg Config) (*Server, error) {
 	}
 
 	reviewStore := reviewstorage.NewMemoryStore()
-	reviewService := reviewing.NewService(reviewStore, causeStore)
+	reviewService := reviewing.NewService(reviewStore, causeService)
 	r.Route("/reviews", revhttp.Handler(reviewService, causeService))
 
 	go (func() {

--- a/internal/app/reviewer.go
+++ b/internal/app/reviewer.go
@@ -73,7 +73,8 @@ func Start(ctx context.Context, cfg Config) (*Server, error) {
 	httpassets.PublicAssets(r)
 
 	causeStore := normStore.NewContributingCauseMemoryStore()
-	_, err = causeStore.Save(ctx, normalized.ContributingCause{
+	causeService := normalized.NewContributingCauseService(causeStore)
+	_, err = causeService.Save(ctx, normalized.ContributingCause{
 		Name:        "Third party outage",
 		Description: "In case a third party experienced issues/outage and it leads to an incident on our side.\nThings like third party changing configuration and it leading to issues on our side also qualifies",
 		Category:    "Design",
@@ -81,7 +82,6 @@ func Start(ctx context.Context, cfg Config) (*Server, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to add default contributing causes: %w", err)
 	}
-	causeService := normalized.NewContributingCauseService(causeStore)
 
 	reviewStore := reviewstorage.NewMemoryStore()
 	reviewService := reviewing.NewService(reviewStore, causeStore)

--- a/internal/normalized/contributingcause.go
+++ b/internal/normalized/contributingcause.go
@@ -16,12 +16,33 @@ type ContributingCause struct {
 	UpdatedAt time.Time
 }
 
+func (cc ContributingCause) updateTimestamps() ContributingCause {
+	now := time.Now()
+	if cc.CreatedAt.IsZero() {
+		cc.CreatedAt = now
+	}
+	cc.UpdatedAt = now
+
+	return cc
+}
+
 type ContributingCauseService struct {
 	store ContributingCauseStorage
 }
 
 func NewContributingCauseService(store ContributingCauseStorage) *ContributingCauseService {
 	return &ContributingCauseService{store: store}
+}
+
+func (s *ContributingCauseService) Save(ctx context.Context, cc ContributingCause) (ContributingCause, error) {
+	cc = cc.updateTimestamps()
+
+	cc, err := s.store.Save(ctx, cc)
+	if err != nil {
+		return cc, fmt.Errorf("failed to store contributing cause: %w", err)
+	}
+
+	return cc, nil
 }
 
 func (s *ContributingCauseService) All(ctx context.Context) ([]ContributingCause, error) {

--- a/internal/normalized/contributingcause.go
+++ b/internal/normalized/contributingcause.go
@@ -9,13 +9,17 @@ import (
 )
 
 type ContributingCause struct {
-	ID          int64
+	ID          int64  `validate:"required"`
 	Name        string `validate:"required"`
 	Description string `validate:"required"`
 	Category    string `validate:"required"`
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
+}
+
+func NewContributingCause() ContributingCause {
+	return ContributingCause{ID: 1} // TODO: Make UUID
 }
 
 func (cc ContributingCause) updateTimestamps() ContributingCause {

--- a/internal/normalized/contributingcause.go
+++ b/internal/normalized/contributingcause.go
@@ -65,3 +65,12 @@ func (s *ContributingCauseService) All(ctx context.Context) ([]ContributingCause
 
 	return ret, nil
 }
+
+func (s *ContributingCauseService) Get(ctx context.Context, id uuid.UUID) (ContributingCause, error) {
+	cc, err := s.store.Get(ctx, id)
+	if err != nil {
+		return ContributingCause{}, fmt.Errorf("failed to get contributing cause: %w", err)
+	}
+
+	return cc, nil
+}

--- a/internal/normalized/contributingcause.go
+++ b/internal/normalized/contributingcause.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/gaqzi/incident-reviewer/internal/platform/validate"
 )
 
 type ContributingCause struct {
@@ -35,6 +37,10 @@ func NewContributingCauseService(store ContributingCauseStorage) *ContributingCa
 }
 
 func (s *ContributingCauseService) Save(ctx context.Context, cc ContributingCause) (ContributingCause, error) {
+	if err := validate.Struct(ctx, cc); err != nil {
+		return cc, fmt.Errorf("failed to validate contributing cause: %w", err)
+	}
+
 	cc = cc.updateTimestamps()
 
 	cc, err := s.store.Save(ctx, cc)

--- a/internal/normalized/contributingcause.go
+++ b/internal/normalized/contributingcause.go
@@ -5,21 +5,23 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/gaqzi/incident-reviewer/internal/platform/validate"
 )
 
 type ContributingCause struct {
-	ID          int64  `validate:"required"`
-	Name        string `validate:"required"`
-	Description string `validate:"required"`
-	Category    string `validate:"required"`
+	ID          uuid.UUID `validate:"required"`
+	Name        string    `validate:"required"`
+	Description string    `validate:"required"`
+	Category    string    `validate:"required"`
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
 
 func NewContributingCause() ContributingCause {
-	return ContributingCause{ID: 1} // TODO: Make UUID
+	return ContributingCause{ID: uuid.Must(uuid.NewV7())}
 }
 
 func (cc ContributingCause) updateTimestamps() ContributingCause {

--- a/internal/normalized/contributingcause_test.go
+++ b/internal/normalized/contributingcause_test.go
@@ -72,7 +72,7 @@ func TestContributingCauseService_Save(t *testing.T) {
 		require.ErrorContains(t, actual, "failed to validate contributing cause:")
 		var errs validator.ValidationErrors
 		require.ErrorAs(t, actual, &errs)
-		require.GreaterOrEqual(t, len(errs), 3, "expected to have at minimum 3 errors for the required fields")
+		require.GreaterOrEqual(t, len(errs), 4, "expected to have at minimum 4 errors for the required fields")
 	})
 
 	t.Run("wraps any error from the store and returns it", func(t *testing.T) {

--- a/internal/normalized/contributingcause_test.go
+++ b/internal/normalized/contributingcause_test.go
@@ -103,6 +103,32 @@ func TestContributingCauseService_Save(t *testing.T) {
 	})
 }
 
+func TestContributingCauseService_Get(t *testing.T) {
+	t.Run("wraps any storage error and returns it", func(t *testing.T) {
+		storage := new(causeStorageMock)
+		storage.Test(t)
+		storage.On("Get", mock.Anything, mock.Anything).Return(normalized.ContributingCause{}, errors.New("uh-oh"))
+		service := normalized.NewContributingCauseService(storage)
+
+		_, actual := service.Get(context.Background(), uuid.Nil)
+
+		require.ErrorContains(t, actual, "failed to get contributing cause:")
+	})
+
+	t.Run("with no errors from storage return the object as-is", func(t *testing.T) {
+		storage := new(causeStorageMock)
+		storage.Test(t)
+		expected := a.ContributingCause().Build()
+		storage.On("Get", mock.Anything, expected.ID).Return(expected, nil)
+		service := normalized.NewContributingCauseService(storage)
+
+		actual, err := service.Get(context.Background(), expected.ID)
+
+		require.NoError(t, err)
+		require.Equal(t, expected, actual, "expected an unchanged contributing cause back")
+	})
+}
+
 func TestContributingCauseService_All(t *testing.T) {
 	t.Run("returns a wrapped error if one is returned from the storage", func(t *testing.T) {
 		storage := new(causeStorageMock)

--- a/internal/normalized/contributingcause_test.go
+++ b/internal/normalized/contributingcause_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/go-playground/validator/v10"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -17,7 +18,7 @@ type causeStorageMock struct {
 	mock.Mock
 }
 
-func (m *causeStorageMock) Get(ctx context.Context, id int64) (normalized.ContributingCause, error) {
+func (m *causeStorageMock) Get(ctx context.Context, id uuid.UUID) (normalized.ContributingCause, error) {
 	args := m.Called(ctx, id)
 	return args.Get(0).(normalized.ContributingCause), args.Error(1)
 }
@@ -119,7 +120,7 @@ func TestContributingCauseService_All(t *testing.T) {
 	t.Run("returns the returned object when no errors", func(t *testing.T) {
 		storage := new(causeStorageMock)
 		storage.Test(t)
-		storage.On("All", mock.Anything).Return([]normalized.ContributingCause{{ID: 1}}, nil)
+		storage.On("All", mock.Anything).Return([]normalized.ContributingCause{a.ContributingCause().Build()}, nil)
 		ctx := context.Background()
 		service := normalized.NewContributingCauseService(storage)
 
@@ -128,7 +129,7 @@ func TestContributingCauseService_All(t *testing.T) {
 
 		require.Equal(
 			t,
-			[]normalized.ContributingCause{{ID: 1}},
+			[]normalized.ContributingCause{a.ContributingCause().Build()},
 			actual,
 		)
 	})

--- a/internal/normalized/contributingcause_test.go
+++ b/internal/normalized/contributingcause_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/go-playground/validator/v10"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -60,6 +61,18 @@ func TestContributingCauseService_Save(t *testing.T) {
 		_, err := service.Save(context.Background(), a.ContributingCause().IsSaved().Build())
 
 		require.NoError(t, err)
+	})
+
+	t.Run("validate the ContributingCause object before saving", func(t *testing.T) {
+		service := normalized.NewContributingCauseService(nil)
+
+		_, actual := service.Save(context.Background(), normalized.ContributingCause{})
+
+		require.Error(t, actual)
+		require.ErrorContains(t, actual, "failed to validate contributing cause:")
+		var errs validator.ValidationErrors
+		require.ErrorAs(t, actual, &errs)
+		require.GreaterOrEqual(t, len(errs), 3, "expected to have at minimum 3 errors for the required fields")
 	})
 
 	t.Run("wraps any error from the store and returns it", func(t *testing.T) {

--- a/internal/normalized/storage.go
+++ b/internal/normalized/storage.go
@@ -1,9 +1,13 @@
 package normalized
 
-import "context"
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
 
 type ContributingCauseStorage interface {
-	Get(ctx context.Context, ID int64) (ContributingCause, error)
+	Get(ctx context.Context, id uuid.UUID) (ContributingCause, error)
 
 	Save(ctx context.Context, cause ContributingCause) (ContributingCause, error)
 

--- a/internal/normalized/storage/causememory.go
+++ b/internal/normalized/storage/causememory.go
@@ -2,12 +2,10 @@ package storage
 
 import (
 	"context"
-	"fmt"
 	"maps"
 	"slices"
 
 	"github.com/gaqzi/incident-reviewer/internal/normalized"
-	"github.com/gaqzi/incident-reviewer/internal/platform/validate"
 )
 
 // TODO: refactor into a generic implementation because the logic is the same across this one and reviewing/storage.MemoryStore.
@@ -33,10 +31,6 @@ func (s *ContributingCauseMemoryStore) Get(_ context.Context, id int64) (normali
 }
 
 func (s *ContributingCauseMemoryStore) Save(ctx context.Context, cause normalized.ContributingCause) (normalized.ContributingCause, error) {
-	if err := validate.Struct(ctx, cause); err != nil {
-		return normalized.ContributingCause{}, fmt.Errorf("failed to validate cause: %w", err)
-	}
-
 	if cause.ID == 0 {
 		s.currentID++
 		cause.ID = s.currentID

--- a/internal/normalized/storage/causememory.go
+++ b/internal/normalized/storage/causememory.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"maps"
 	"slices"
-	"time"
 
 	"github.com/gaqzi/incident-reviewer/internal/normalized"
 	"github.com/gaqzi/incident-reviewer/internal/platform/validate"
@@ -42,12 +41,6 @@ func (s *ContributingCauseMemoryStore) Save(ctx context.Context, cause normalize
 		s.currentID++
 		cause.ID = s.currentID
 	}
-
-	now := time.Now()
-	if cause.CreatedAt.IsZero() {
-		cause.CreatedAt = now
-	}
-	cause.UpdatedAt = now
 
 	s.data[cause.ID] = cause
 

--- a/internal/normalized/storage/causememory.go
+++ b/internal/normalized/storage/causememory.go
@@ -11,8 +11,7 @@ import (
 // TODO: refactor into a generic implementation because the logic is the same across this one and reviewing/storage.MemoryStore.
 
 type ContributingCauseMemoryStore struct {
-	data      map[int64]normalized.ContributingCause
-	currentID int64
+	data map[int64]normalized.ContributingCause
 }
 
 func NewContributingCauseMemoryStore() *ContributingCauseMemoryStore {
@@ -30,10 +29,9 @@ func (s *ContributingCauseMemoryStore) Get(_ context.Context, id int64) (normali
 	return cause, nil
 }
 
-func (s *ContributingCauseMemoryStore) Save(ctx context.Context, cause normalized.ContributingCause) (normalized.ContributingCause, error) {
+func (s *ContributingCauseMemoryStore) Save(_ context.Context, cause normalized.ContributingCause) (normalized.ContributingCause, error) {
 	if cause.ID == 0 {
-		s.currentID++
-		cause.ID = s.currentID
+		return normalized.ContributingCause{}, NoIDError
 	}
 
 	s.data[cause.ID] = cause

--- a/internal/normalized/storage/errors.go
+++ b/internal/normalized/storage/errors.go
@@ -3,10 +3,12 @@ package storage
 import (
 	"errors"
 	"fmt"
+
+	"github.com/google/uuid"
 )
 
 type NoContributingCauseError struct {
-	ID int64
+	ID uuid.UUID
 }
 
 func (e *NoContributingCauseError) Error() string {

--- a/internal/normalized/storage/errors.go
+++ b/internal/normalized/storage/errors.go
@@ -1,6 +1,9 @@
 package storage
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 type NoContributingCauseError struct {
 	ID int64
@@ -9,3 +12,6 @@ type NoContributingCauseError struct {
 func (e *NoContributingCauseError) Error() string {
 	return fmt.Sprintf("contributing cause not found by id: %d", e.ID)
 }
+
+// NoIDError indicates that the passed in uuid ID is blank/uninitialized.
+var NoIDError = errors.New("can't store contributing cause because ID is not set")

--- a/internal/normalized/storage/storage_test.go
+++ b/internal/normalized/storage/storage_test.go
@@ -19,25 +19,21 @@ func TestCauseMemoryStore(t *testing.T) {
 
 func ContributingCauseStorageTest(t *testing.T, ctx context.Context, storeFactory func() normalized.ContributingCauseStorage) {
 	t.Run("Save", func(t *testing.T) {
-		t.Run("an object with all fields set correctly, it saves without an error and a PK is set", func(t *testing.T) {
-			cause := a.ContributingCause().IsNotSaved().Build()
+		t.Run("returns an error when trying to save without an ID set", func(t *testing.T) {
 			store := storeFactory()
 
-			actual, err := store.Save(ctx, cause)
+			_, actual := store.Save(ctx, normalized.ContributingCause{})
+
+			require.ErrorIs(t, actual, storage.NoIDError, "expected the sentinel error for not having an ID set")
+		})
+
+		t.Run("an object with the ID set is saved without errors", func(t *testing.T) {
+			cause := normalized.NewContributingCause()
+			store := storeFactory()
+
+			_, err := store.Save(ctx, cause)
 
 			require.NoError(t, err, "expected to have saved when all fields are set")
-			require.NotEmpty(t, actual.ID, "expected the ID to be set to something when saved, is there an error that wasn't covered?")
-			require.Equal(
-				t,
-				normalized.ContributingCause{
-					ID:          actual.ID,
-					Name:        cause.Name,
-					Description: cause.Description,
-					Category:    cause.Category,
-				},
-				actual,
-				"expected to have saved the values as passed in, and set the generated or automatic values",
-			)
 		})
 	})
 

--- a/internal/normalized/storage/storage_test.go
+++ b/internal/normalized/storage/storage_test.go
@@ -2,10 +2,8 @@ package storage_test
 
 import (
 	"context"
-	"errors"
 	"testing"
 
-	"github.com/go-playground/validator/v10"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gaqzi/incident-reviewer/internal/normalized"
@@ -41,89 +39,77 @@ func ContributingCauseStorageTest(t *testing.T, ctx context.Context, storeFactor
 				"expected to have saved the values as passed in, and set the generated or automatic values",
 			)
 		})
+	})
 
-		t.Run("with an empty cause it fails because the required fields are empty", func(t *testing.T) {
-			cause := normalized.ContributingCause{}
+	t.Run("Get", func(t *testing.T) {
+		t.Run("returns an error when an item with the given PK doesn't exist in the store", func(t *testing.T) {
 			store := storeFactory()
 
-			_, err := store.Save(ctx, cause)
-			require.Error(t, err, "expected an error from failing validation")
+			_, err := store.Get(ctx, 1_000)
+			require.Error(t, err, "expected to not have found an item when it's not in the store")
 
-			var errs validator.ValidationErrors
-			require.True(t, errors.As(err, &errs), "expected to have converted to validator.ValidationErrors")
-			require.GreaterOrEqual(t, len(errs), 3, "expected to have at least 2 fields failing at hte time of writing: %s", err)
+			var actualErr *storage.NoContributingCauseError
+			require.ErrorAs(t, err, &actualErr, "expected the specific error for not found")
 		})
 
-		t.Run("Get", func(t *testing.T) {
-			t.Run("returns an error when an item with the given PK doesn't exist in the store", func(t *testing.T) {
-				store := storeFactory()
+		t.Run("after saving, gets back the same object as save when asking by ID", func(t *testing.T) {
+			store := storeFactory()
+			expected, err := store.Save(ctx, a.ContributingCause().Build())
+			require.NoError(t, err, "expected the valid review to have been saved successfully")
 
-				_, err := store.Get(ctx, 1_000)
-				require.Error(t, err, "expected to not have found an item when it's not in the store")
+			actual, err := store.Get(ctx, expected.ID)
+			require.NoError(t, err, "expected to have fetched successfully when just saving the object")
 
-				var actualErr *storage.NoContributingCauseError
-				require.ErrorAs(t, err, &actualErr, "expected the specific error for not found")
-			})
+			require.Equal(t, actual, expected, "expected the objects to have the same info when no changes between save and fetch")
+		})
+	})
 
-			t.Run("after saving, gets back the same object as save when asking by ID", func(t *testing.T) {
-				store := storeFactory()
-				expected, err := store.Save(ctx, a.ContributingCause().Build())
-				require.NoError(t, err, "expected the valid review to have been saved successfully")
+	t.Run("All", func(t *testing.T) {
+		t.Run("with no stored reviews it returns an empty list", func(t *testing.T) {
+			store := storeFactory()
 
-				actual, err := store.Get(ctx, expected.ID)
-				require.NoError(t, err, "expected to have fetched successfully when just saving the object")
+			reviews, err := store.All(ctx)
+			require.NoError(t, err)
 
-				require.Equal(t, actual, expected, "expected the objects to have the same info when no changes between save and fetch")
-			})
+			require.Empty(t, reviews, "expected to have gotten back no items")
 		})
 
-		t.Run("All", func(t *testing.T) {
-			t.Run("with no stored reviews it returns an empty list", func(t *testing.T) {
-				store := storeFactory()
+		t.Run("returns the only stored item when only one exists", func(t *testing.T) {
+			store := storeFactory()
+			cause, err := store.Save(ctx, a.ContributingCause().Build())
+			require.NoError(t, err, "expected to have saved successfully")
 
-				reviews, err := store.All(ctx)
-				require.NoError(t, err)
+			actual, err := store.All(ctx)
+			require.NoError(t, err)
 
-				require.Empty(t, reviews, "expected to have gotten back no items")
-			})
+			require.NotEmpty(t, actual)
+			require.Equal(
+				t,
+				[]normalized.ContributingCause{cause},
+				actual,
+				"expected to have gotten back an item matching the only stored one",
+			)
+		})
 
-			t.Run("returns the only stored item when only one exists", func(t *testing.T) {
-				store := storeFactory()
-				cause, err := store.Save(ctx, a.ContributingCause().Build())
-				require.NoError(t, err, "expected to have saved successfully")
+		t.Run("with multiple reviews, returns them in descending creation order", func(t *testing.T) {
+			store := storeFactory()
+			cause1, err := store.Save(ctx, a.ContributingCause().Build())
+			require.NoError(t, err, "expected to have saved successfully")
+			cause2, err := store.Save(ctx, a.ContributingCause().WithID(2).WithName("Unbounded resource utilization").Build())
+			require.NoError(t, err)
 
-				actual, err := store.All(ctx)
-				require.NoError(t, err)
+			actual, err := store.All(ctx)
+			require.NoError(t, err)
 
-				require.NotEmpty(t, actual)
-				require.Equal(
-					t,
-					[]normalized.ContributingCause{cause},
-					actual,
-					"expected to have gotten back an item matching the only stored one",
-				)
-			})
-
-			t.Run("with multiple reviews, returns them in descending creation order", func(t *testing.T) {
-				store := storeFactory()
-				cause1, err := store.Save(ctx, a.ContributingCause().Build())
-				require.NoError(t, err, "expected to have saved successfully")
-				cause2, err := store.Save(ctx, a.ContributingCause().WithID(2).WithName("Unbounded resource utilization").Build())
-				require.NoError(t, err)
-
-				actual, err := store.All(ctx)
-				require.NoError(t, err)
-
-				require.Equal(
-					t,
-					[]normalized.ContributingCause{
-						cause2,
-						cause1,
-					},
-					actual,
-					"expected the most recently created item to be returned first",
-				)
-			})
+			require.Equal(
+				t,
+				[]normalized.ContributingCause{
+					cause2,
+					cause1,
+				},
+				actual,
+				"expected the most recently created item to be returned first",
+			)
 		})
 	})
 }

--- a/internal/normalized/storage/storage_test.go
+++ b/internal/normalized/storage/storage_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gaqzi/incident-reviewer/internal/normalized"
@@ -41,7 +42,7 @@ func ContributingCauseStorageTest(t *testing.T, ctx context.Context, storeFactor
 		t.Run("returns an error when an item with the given PK doesn't exist in the store", func(t *testing.T) {
 			store := storeFactory()
 
-			_, err := store.Get(ctx, 1_000)
+			_, err := store.Get(ctx, uuid.Nil)
 			require.Error(t, err, "expected to not have found an item when it's not in the store")
 
 			var actualErr *storage.NoContributingCauseError
@@ -91,7 +92,7 @@ func ContributingCauseStorageTest(t *testing.T, ctx context.Context, storeFactor
 			store := storeFactory()
 			cause1, err := store.Save(ctx, a.ContributingCause().Build())
 			require.NoError(t, err, "expected to have saved successfully")
-			cause2, err := store.Save(ctx, a.ContributingCause().WithID(2).WithName("Unbounded resource utilization").Build())
+			cause2, err := store.Save(ctx, a.ContributingCause().WithID(uuid.Must(uuid.NewV7())).WithName("Unbounded resource utilization").Build())
 			require.NoError(t, err)
 
 			actual, err := store.All(ctx)

--- a/internal/reviewing/http/handler.go
+++ b/internal/reviewing/http/handler.go
@@ -35,7 +35,7 @@ type reviewingService interface {
 	All(ctx context.Context) ([]reviewing.Review, error)
 
 	// AddContributingCause validates that the cause can be added to the review.
-	AddContributingCause(ctx context.Context, reviewID uuid.UUID, causeID int64, why string) error
+	AddContributingCause(ctx context.Context, reviewID uuid.UUID, causeID uuid.UUID, why string) error
 }
 
 type causeAller interface {
@@ -105,7 +105,7 @@ type ReviewBasic struct {
 
 type ReviewCauseForm struct {
 	ReviewID            uuid.UUID `form:"reviewID"`
-	ContributingCauseID int64     `form:"contributingCauseID"`
+	ContributingCauseID uuid.UUID `form:"contributingCauseID"`
 	Why                 string    `form:"why"`
 
 	UpdatedAt time.Time
@@ -119,7 +119,7 @@ type ReviewCauseBasic struct {
 }
 
 type ContributingCauseBasic struct {
-	ID          int64
+	ID          uuid.UUID
 	Name        string
 	Description string
 	Category    string

--- a/internal/reviewing/review.go
+++ b/internal/reviewing/review.go
@@ -67,7 +67,7 @@ type ReviewCause struct {
 }
 
 type causeStore interface {
-	Get(ctx context.Context, ID int64) (normalized.ContributingCause, error)
+	Get(ctx context.Context, id uuid.UUID) (normalized.ContributingCause, error)
 }
 
 type Service struct {
@@ -115,7 +115,7 @@ func (s *Service) All(ctx context.Context) ([]Review, error) {
 	return ret, nil
 }
 
-func (s *Service) AddContributingCause(ctx context.Context, reviewID uuid.UUID, causeID int64, why string) error {
+func (s *Service) AddContributingCause(ctx context.Context, reviewID uuid.UUID, causeID uuid.UUID, why string) error {
 	review, err := s.reviewStore.Get(ctx, reviewID)
 	if err != nil {
 		return fmt.Errorf("failed to get review: %w", err)

--- a/internal/reviewing/storage/errors.go
+++ b/internal/reviewing/storage/errors.go
@@ -15,5 +15,5 @@ func (e *NoReviewError) Error() string {
 	return fmt.Sprintf("review not found by id: %d", e.ID)
 }
 
-// NoIDError indicates that the passed in uuid ID is blank/uninitialized.
+// NoIDError indicates that the passed in ID is blank/uninitialized.
 var NoIDError = errors.New("can't store review because ID is not set")

--- a/test/a/contributingcause.go
+++ b/test/a/contributingcause.go
@@ -17,6 +17,7 @@ func ContributingCause() BuilderContributingCause {
 }
 
 func (b BuilderContributingCause) IsValid() BuilderContributingCause {
+	b.c.ID = 1
 	b.c.Name = "Third Party Outage"
 	b.c.Description = "When things go wrong for others"
 	b.c.Category = "Design" // because we can mitigate these by designing differently, mostly
@@ -46,7 +47,6 @@ func (b BuilderContributingCause) IsSaved() BuilderContributingCause {
 }
 
 func (b BuilderContributingCause) IsNotSaved() BuilderContributingCause {
-	b.c.ID = 0
 	b.c.CreatedAt = time.Time{}
 	b.c.UpdatedAt = time.Time{}
 

--- a/test/a/contributingcause.go
+++ b/test/a/contributingcause.go
@@ -3,6 +3,8 @@ package a
 import (
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/gaqzi/incident-reviewer/internal/normalized"
 )
 
@@ -17,7 +19,7 @@ func ContributingCause() BuilderContributingCause {
 }
 
 func (b BuilderContributingCause) IsValid() BuilderContributingCause {
-	b.c.ID = 1
+	b.c.ID = uuid.MustParse("0193ddee-c2e6-72d6-ad36-9d4cee8a5e2f") // UUIDv7, just a value, no particular meaning
 	b.c.Name = "Third Party Outage"
 	b.c.Description = "When things go wrong for others"
 	b.c.Category = "Design" // because we can mitigate these by designing differently, mostly
@@ -39,7 +41,6 @@ func (b BuilderContributingCause) IsSaved() BuilderContributingCause {
 		panic("failed to parse example timestamp: " + err.Error())
 	}
 
-	b.c.ID = 1
 	b.c.CreatedAt = createdAt
 	b.c.UpdatedAt = createdAt
 
@@ -53,7 +54,7 @@ func (b BuilderContributingCause) IsNotSaved() BuilderContributingCause {
 	return b
 }
 
-func (b BuilderContributingCause) WithID(id int64) BuilderContributingCause {
+func (b BuilderContributingCause) WithID(id uuid.UUID) BuilderContributingCause {
 	b.c.ID = id
 
 	return b

--- a/test/a/contributingcause.go
+++ b/test/a/contributingcause.go
@@ -1,0 +1,79 @@
+package a
+
+import (
+	"time"
+
+	"github.com/gaqzi/incident-reviewer/internal/normalized"
+)
+
+type BuilderContributingCause struct {
+	c normalized.ContributingCause
+}
+
+func ContributingCause() BuilderContributingCause {
+	return BuilderContributingCause{}.
+		IsValid().
+		IsSaved()
+}
+
+func (b BuilderContributingCause) IsValid() BuilderContributingCause {
+	b.c.Name = "Third Party Outage"
+	b.c.Description = "When things go wrong for others"
+	b.c.Category = "Design" // because we can mitigate these by designing differently, mostly
+
+	return b
+}
+
+func (b BuilderContributingCause) IsInvalid() BuilderContributingCause {
+	b.c.Name = ""
+	b.c.Description = ""
+	b.c.Category = ""
+
+	return b
+}
+
+func (b BuilderContributingCause) IsSaved() BuilderContributingCause {
+	createdAt, err := time.Parse(time.RFC3339Nano, "2024-12-19T07:25:30.1337Z")
+	if err != nil {
+		panic("failed to parse example timestamp: " + err.Error())
+	}
+
+	b.c.ID = 1
+	b.c.CreatedAt = createdAt
+	b.c.UpdatedAt = createdAt
+
+	return b
+}
+
+func (b BuilderContributingCause) IsNotSaved() BuilderContributingCause {
+	b.c.ID = 0
+	b.c.CreatedAt = time.Time{}
+	b.c.UpdatedAt = time.Time{}
+
+	return b
+}
+
+func (b BuilderContributingCause) WithID(id int64) BuilderContributingCause {
+	b.c.ID = id
+
+	return b
+}
+
+func (b BuilderContributingCause) WithName(n string) BuilderContributingCause {
+	b.c.Name = n
+
+	return b
+}
+
+func (b BuilderContributingCause) Modify(mods ...func(cc *normalized.ContributingCause)) BuilderContributingCause {
+	for _, m := range mods {
+		m(&b.c)
+	}
+
+	return b
+
+}
+
+func (b BuilderContributingCause) Build() normalized.ContributingCause {
+	return b.c
+}


### PR DESCRIPTION
- **Set timestamps in service instead of store**
  

- **Move validation into the service**
  

- **Make the ID of the cause required when saving**
  

- **Use UUID instead of int64 for ContributingCause ID**
  

- **Add Get to contributing cause service**
  So all the collaboration goes through the service for consistency.
  
  It really doesn't matter for the get, but felt like I can be consistent
  in what I ask from my collaborators at least?
  