### PR TITLE
move logic out of service and into a collaborator

### DIFF
--- a/internal/app/web/templates/contributing-causes/binding/__causes-options.html
+++ b/internal/app/web/templates/contributing-causes/binding/__causes-options.html
@@ -1,5 +1,5 @@
 {{ define "bind-contributing-cause-options" }}
-<li id="causes" hx-target="this" hx-replace-url="false">
+<li id="causes" hx-target="this" hx-swap="innerHTML" hx-replace-url="false">
     <label>
         <dfn title="A part of why we had an incident">Contributing cause</dfn>:
         {{ $selectedID := .SelectedCauseID }}

--- a/internal/app/web/templates/contributing-causes/binding/_form.html
+++ b/internal/app/web/templates/contributing-causes/binding/_form.html
@@ -8,6 +8,12 @@
                 <textarea name="why" required>{{ .Data.ContributingCause.Why }}</textarea>
             </label>
         </li>
+        <li>
+            <label>
+                Is this the <defn title="the cause closest to what broke, also often known as the root cause">proximal cause</defn>?
+                <input type="checkbox" name="isProximalCause" {{ if .Data.ContributingCause.IsProximalCause }}checked{{ end }}>
+            </label>
+        </li>
     </ul>
 
     <button class="bind" type="submit">Add!</button>

--- a/internal/app/web/templates/reviews/_contributing-causes.html
+++ b/internal/app/web/templates/reviews/_contributing-causes.html
@@ -1,4 +1,4 @@
-<contributing-causes hx-target="this">
+<contributing-causes hx-target="this" hx-swap="outerHTML">
     {{ .Partials.BindContributingCause }}
 
     <ul class="listing">

--- a/internal/app/web/templates/reviews/_contributing-causes.html
+++ b/internal/app/web/templates/reviews/_contributing-causes.html
@@ -3,7 +3,9 @@
 
     <ul class="listing">
         {{ range .Data.BoundContributingCauses }}
-        <li><span class="contributingCause">{{ .Name }}</span> — <span class="why">{{ .Why }}</span></li>
+        <li{{ if .IsProximalCause }} class="proximalCause"{{ end }}>
+            <span class="contributingCause">{{ .Name }}</span> — <span class="why">{{ .Why }}</span>
+        </li>
         {{ end }}
     </ul>
 </contributing-causes>

--- a/internal/app/web/templates/reviews/base.html
+++ b/internal/app/web/templates/reviews/base.html
@@ -4,7 +4,8 @@
     <title>Incident Reviewer</title>
     <meta charset="utf-8">
     <style>
-        section, root-causes {
+        section, contributing-causes {
+            display: block;
             border: 1px solid black;
             margin: 1em 0;
             padding: 0 1em 1em 1em;

--- a/internal/app/web/templates/reviews/base.html
+++ b/internal/app/web/templates/reviews/base.html
@@ -10,6 +10,10 @@
             margin: 1em 0;
             padding: 0 1em 1em 1em;
         }
+
+        defn {
+            text-decoration: underline dotted;
+        }
     </style>
     <script src="/assets/htmx-2.0.2.min.js"></script>
     <!--

--- a/internal/platform/action/mapper.go
+++ b/internal/platform/action/mapper.go
@@ -1,0 +1,42 @@
+package action
+
+import (
+	"errors"
+	"maps"
+	"slices"
+)
+
+// Mapper provides "dynamic" injection of actions in services.
+// The idea is to make sure your service objects keep doing collaboration while also
+// giving them a way to declare how they want to collaborate with their aggregate roots,
+// which perform business logic, and may need to be called to let the service object
+// perform their various actions.
+// So Instead of forcing each caller to keep track of how to perform all the steps of the
+// action, we can name it, provide a default, and use that during normal execution, and
+// then provide a mocked version in testing.
+type Mapper struct {
+	actions map[string]any
+}
+
+func (m *Mapper) Add(name string, fn any) *Mapper {
+	if m.actions == nil {
+		m.actions = make(map[string]any)
+	}
+
+	m.actions[name] = fn
+
+	return m
+}
+
+func (m *Mapper) Get(name string) (any, error) {
+	v, ok := m.actions[name]
+	if !ok {
+		return nil, errors.New("no action found for: " + name)
+	}
+
+	return v, nil
+}
+
+func (m *Mapper) All() []string {
+	return slices.Collect(maps.Keys(m.actions))
+}

--- a/internal/platform/action/mapper_test.go
+++ b/internal/platform/action/mapper_test.go
@@ -1,0 +1,53 @@
+package action_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gaqzi/incident-reviewer/internal/platform/action"
+)
+
+type (
+	testStructA struct{}
+	testStructB struct{}
+)
+
+func TestMapper(t *testing.T) {
+	t.Run("when no named action found return an error", func(t *testing.T) {
+		mapper := &action.Mapper{}
+
+		doer, err := mapper.Get("ComplexCalculation")
+
+		require.ErrorContains(t, err, "no action found for: ComplexCalculation")
+		require.Nil(t, doer)
+	})
+
+	t.Run("returns the saved function for a name", func(t *testing.T) {
+		mapper := &action.Mapper{}
+		mapper.Add("ComplexCalculation", func(a testStructA, b testStructB) error { return nil })
+
+		doer, err := mapper.Get("ComplexCalculation")
+		require.NoError(t, err)
+
+		do, ok := doer.(func(testStructA, testStructB) error)
+		require.True(t, ok)
+		require.NotNil(t, do)
+
+		require.NoError(t, do(testStructA{}, testStructB{}))
+	})
+
+	t.Run("All returns the name of each stored action", func(t *testing.T) {
+		mapper := &action.Mapper{}
+		require.Empty(t, mapper.All(), "expected a just initialized mapper to have nothing to show")
+
+		mapper.Add("ComplexFunction", func() {})
+		mapper.Add("SimpleFunction", func() {})
+		require.ElementsMatch(
+			t,
+			[]string{"ComplexFunction", "SimpleFunction"},
+			mapper.All(),
+			"expected the names of the stored actions to be returned",
+		)
+	})
+}

--- a/internal/reviewing/serviceactions.go
+++ b/internal/reviewing/serviceactions.go
@@ -1,0 +1,34 @@
+package reviewing
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gaqzi/incident-reviewer/internal/normalized/contributing"
+	"github.com/gaqzi/incident-reviewer/internal/platform/action"
+	"github.com/gaqzi/incident-reviewer/internal/platform/validate"
+)
+
+// reviewServiceActions provides actions to be taken as pre-hooks in my reviewing.Service.
+// It's a way for me to keep certain logic private (so it doesn't leak in my public interface) while
+// also keeping the service clean in that it only does collaboration.
+// I'm not 100% about this pattern, but I'm making pieces that are either about collaboration or logic, so it's
+// something.
+func reviewServiceActions() *action.Mapper {
+	m := &action.Mapper{}
+
+	m.Add("AddContributingCause", func(r Review, c contributing.Cause, rc ReviewCause) (Review, error) {
+		rc.Cause = c
+		return r.AddContributingCause(rc)
+	})
+
+	m.Add("Save", func(ctx context.Context, r Review) (Review, error) {
+		if err := validate.Struct(ctx, r); err != nil {
+			return r, fmt.Errorf("failed to validate review: %w", err)
+		}
+
+		return r.updateTimestamps(), nil
+	})
+
+	return m
+}

--- a/internal/reviewing/serviceactions_test.go
+++ b/internal/reviewing/serviceactions_test.go
@@ -1,0 +1,107 @@
+package reviewing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gaqzi/incident-reviewer/internal/normalized/contributing"
+)
+
+func TestActionMapper(t *testing.T) {
+	t.Run("the default mapper covers all actions with custom behavior on the Review", func(t *testing.T) {
+		mapper := reviewServiceActions()
+
+		require.ElementsMatch(
+			t,
+			[]string{
+				"AddContributingCause",
+				"Save",
+			},
+			mapper.All(),
+			"expected all causes to be listed here so we catch when we add new or remove one",
+		)
+	})
+
+	t.Run("AddContributingCause sets the contributing.Cause on the ReviewCause before adding it to the Review", func(t *testing.T) {
+		mapper := reviewServiceActions()
+
+		doer, err := mapper.Get("AddContributingCause")
+		require.NoError(t, err)
+		do, ok := doer.(func(Review, contributing.Cause, ReviewCause) (Review, error))
+		require.True(t, ok)
+
+		cause := contributing.Cause{Name: "Something"}
+		review, err := do(Review{}, cause, ReviewCause{})
+		require.NoError(t, err)
+
+		require.Equal(
+			t,
+			Review{ContributingCauses: []ReviewCause{{Cause: cause}}},
+			review,
+			"expected the contributing cause to have been set on the ReviewCause and then added to the Review",
+		)
+	})
+
+	t.Run("Save validates and returns an error when it fails to validate", func(t *testing.T) {
+		mapper := reviewServiceActions()
+
+		doer, actual := mapper.Get("Save")
+		require.NoError(t, actual)
+		do, ok := doer.(func(context.Context, Review) (Review, error))
+		require.True(t, ok)
+
+		_, actual = do(context.Background(), Review{})
+
+		var errs validator.ValidationErrors
+		require.ErrorAs(t, actual, &errs, "expected to have gotten back validation errors")
+		require.ErrorContains(t, actual, "failed to validate review:")
+		require.GreaterOrEqual(t, len(errs), 8, "expected at minimum 8 errors to match the fields at the time of writing")
+	})
+
+	t.Run("Save updates the timestamps after successfully validating", func(t *testing.T) {
+
+	})
+}
+
+// Why is this test here? Because it's testing something _inside_ the reviewing package and
+// this is the one test I have that operates in here. It's also why I'm not using the `a` helpers
+// because I would be causing a recursive import loop.
+func TestReview_updateTimestamps(t *testing.T) {
+	validReview := func() Review {
+		return Review{
+			ID:                  uuid.Nil,
+			URL:                 "http://example.com",
+			Title:               "example",
+			Description:         "example",
+			Impact:              "example",
+			Where:               "example",
+			ReportProximalCause: "example",
+			ReportTrigger:       "example",
+		}
+	}
+
+	t.Run("when timestamps are zero both are set to now", func(t *testing.T) {
+		r := validReview()
+
+		r = r.updateTimestamps()
+
+		require.NotZero(t, r.CreatedAt, "expected to have been set")
+		require.Equal(t, r.CreatedAt, r.UpdatedAt, "expected to have been set to the same when both are blank")
+	})
+
+	t.Run("when created at already is set then only updated at is updated", func(t *testing.T) {
+		r := validReview()
+		now := time.Now()
+		r.CreatedAt = now
+
+		time.Sleep(time.Millisecond) // to give us some time to make the comparisons work
+		r = r.updateTimestamps()
+
+		require.Greater(t, r.UpdatedAt.UnixNano(), r.CreatedAt.UnixNano(), "expected the updated at to be after created at")
+	})
+}

--- a/test/a/review.go
+++ b/test/a/review.go
@@ -91,3 +91,13 @@ func (b BuilderReview) Modify(mods ...func(r *reviewing.Review)) BuilderReview {
 
 	return b
 }
+
+func (b BuilderReview) WithContributingCause(rc reviewing.ReviewCause) BuilderReview {
+	r, err := b.r.AddContributingCause(rc)
+	if err != nil {
+		panic("failed to add contributing cause: " + err.Error())
+	}
+	b.r = r
+
+	return b
+}


### PR DESCRIPTION
- **Allow for one proximal cause amongst bound causes**
  

- **Show contributing-causes as a section**
  

- **Give some basic styling for the defn**
  So people can see it's there, it needs some more lovin' but a start.
  

- **Mark up how to swap everywhere when setting it**
  Because it's an inherited attribute, so if a child hx-target will get
  whatever the parent sets, which luckily broke my tests so I could tell.
  

- **Move logic out of service and into a collaborator**
  So that the tests in the service are way more reasonable and so as I
  keep extending the logic they fit together better.
  
  I kinda like where this is going, but I feel a bit iffy about it.
  Looking forward to hearing more from other people as I show it.
  