### PR TITLE
refactor service mock setup into a helper

### DIFF
--- a/internal/app/web/partials.go
+++ b/internal/app/web/partials.go
@@ -39,6 +39,7 @@ func contributingCausesComponent(reviewID uuid.UUID, ccs []contributing.Cause, b
 			),
 			"BindContributingCause",
 		).
+		Attach("templates/reviews/__contributing-cause-bound-li.html").
 		AddData("BoundContributingCauses", boundCauses).
 		AddData("ReviewID", reviewID)
 }

--- a/internal/app/web/templates/contributing-causes/binding/_form.html
+++ b/internal/app/web/templates/contributing-causes/binding/_form.html
@@ -1,4 +1,8 @@
+{{ if .Data.ContributingCause.Why }}
+<form method="post" action="/reviews/{{ .Data.ReviewID }}/contributing-causes/{{ .Data.ContributingCause.ID }}/edit" class="new">
+{{ else }}
 <form method="post" action="/reviews/{{ .Data.ReviewID }}/contributing-causes" class="new">
+{{ end }}
     <ul>
         {{ template "bind-contributing-cause-options" .Data }}
 
@@ -16,5 +20,5 @@
         </li>
     </ul>
 
-    <button class="bind" type="submit">Add!</button>
+    <button class="bind" type="submit">{{ if .Data.ContributingCause.Why }}Save{{else}}Add!{{end}}</button>
 </form>

--- a/internal/app/web/templates/reviews/__contributing-cause-bound-li.html
+++ b/internal/app/web/templates/reviews/__contributing-cause-bound-li.html
@@ -1,0 +1,8 @@
+{{ define "contributing-cause-bound-li" }}
+<li{{ if .ContributingCause.IsProximalCause }} class="proximalCause"{{ end }} hx-target="this" hx-swap="innerHTML">
+    <form method="get" action="/reviews/{{ .ReviewID }}/contributing-causes/{{ .ContributingCause.ID }}/edit">
+        <button class="edit" type="submit" title="Edit">✍️</button>
+    </form>
+    <span class="contributingCause">{{ .ContributingCause.Name }}</span> — <span class="why">{{ .ContributingCause.Why }}</span>
+</li>
+{{ end }}

--- a/internal/app/web/templates/reviews/_contributing-causes.html
+++ b/internal/app/web/templates/reviews/_contributing-causes.html
@@ -3,7 +3,10 @@
 
     <ul class="listing">
         {{ range .Data.BoundContributingCauses }}
-        <li{{ if .IsProximalCause }} class="proximalCause"{{ end }}>
+        <li{{ if .IsProximalCause }} class="proximalCause"{{ end }} hx-target="this" hx-swap="innerHTML">
+            <form method="get" action="/reviews/{{ $.Data.ReviewID }}/contributing-causes/{{ .ID }}/edit">
+                <button class="edit" type="submit" title="Edit">✍️</button>
+            </form>
             <span class="contributingCause">{{ .Name }}</span> — <span class="why">{{ .Why }}</span>
         </li>
         {{ end }}

--- a/internal/app/web/templates/reviews/only-contributing-cause-bound-li.html
+++ b/internal/app/web/templates/reviews/only-contributing-cause-bound-li.html
@@ -1,0 +1,1 @@
+{{ template "contributing-cause-bound-li" .Data }}

--- a/internal/reviewing/serviceactions.go
+++ b/internal/reviewing/serviceactions.go
@@ -22,6 +22,10 @@ func reviewServiceActions() *action.Mapper {
 		return r.AddContributingCause(rc)
 	})
 
+	m.Add("UpdateBoundContributingCause", func(r Review, o ReviewCause) (Review, error) {
+		return r.UpdateBoundContributingCause(o)
+	})
+
 	m.Add("Save", func(ctx context.Context, r Review) (Review, error) {
 		if err := validate.Struct(ctx, r); err != nil {
 			return r, fmt.Errorf("failed to validate review: %w", err)

--- a/test/a/review.go
+++ b/test/a/review.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/gaqzi/incident-reviewer/internal/normalized/contributing"
 	"github.com/gaqzi/incident-reviewer/internal/reviewing"
 )
 
@@ -92,12 +93,63 @@ func (b BuilderReview) Modify(mods ...func(r *reviewing.Review)) BuilderReview {
 	return b
 }
 
-func (b BuilderReview) WithContributingCause(rc reviewing.ReviewCause) BuilderReview {
-	r, err := b.r.AddContributingCause(rc)
-	if err != nil {
-		panic("failed to add contributing cause: " + err.Error())
+func (b BuilderReview) WithContributingCause(rcs ...reviewing.ReviewCause) BuilderReview {
+	if len(rcs) == 0 {
+		rcs = append(rcs, ReviewCause().Build())
 	}
-	b.r = r
+
+	for _, rc := range rcs {
+		r, err := b.r.AddContributingCause(rc)
+		if err != nil {
+			panic("failed to add contributing cause: " + err.Error())
+		}
+		b.r = r
+	}
 
 	return b
+}
+
+type BuilderReviewCause struct {
+	rc reviewing.ReviewCause
+}
+
+func ReviewCause() BuilderReviewCause {
+	return BuilderReviewCause{}.
+		IsValid()
+}
+
+func (b BuilderReviewCause) WithID(id uuid.UUID) BuilderReviewCause {
+	b.rc.ID = id
+
+	return b
+}
+
+func (b BuilderReviewCause) WithCause(c contributing.Cause) BuilderReviewCause {
+	b.rc.Cause = c
+
+	return b
+}
+
+func (b BuilderReviewCause) WithWhy(s string) BuilderReviewCause {
+	b.rc.Why = s
+
+	return b
+}
+
+func (b BuilderReviewCause) IsValid() BuilderReviewCause {
+	b.rc.ID = uuid.MustParse("0193f6e0-a83b-71aa-a712-b0f7e0521108")
+	b.rc.Cause = ContributingCause().Build()
+	b.rc.Why = "We rely on basic internet infrastructure like everyone else"
+
+	return b
+}
+
+func (b BuilderReviewCause) WithIsProximalCause(tf bool) BuilderReviewCause {
+	b.rc.IsProximalCause = tf
+
+	return b
+}
+
+func (b BuilderReviewCause) Build() reviewing.ReviewCause {
+	return b.rc
 }

--- a/test/a/uuid.go
+++ b/test/a/uuid.go
@@ -1,0 +1,8 @@
+package a
+
+import "github.com/google/uuid"
+
+// UUID returns a new random UUID.
+func UUID() uuid.UUID {
+	return uuid.Must(uuid.NewV7())
+}

--- a/test/reviewing_test.go
+++ b/test/reviewing_test.go
@@ -143,7 +143,7 @@ func TestReviewing(t *testing.T) {
 		require.NoError(t, causesForm.Locator(`button.bind[type="submit"]`).Click())
 
 		causesListing := page.Locator(`contributing-causes ul.listing`)
-		firstCause := causesListing.Locator(`li`)
+		firstCause := causesListing.Locator(`li`).First()
 		require.NoError(
 			t,
 			assert.Locator(firstCause).ToHaveCount(1),
@@ -181,6 +181,12 @@ func TestReviewing(t *testing.T) {
 			assert.Locator(causesListing.Locator(`li.proximalCause .contributingCause`)).ToHaveText("__Inconceivable__"),
 			"expected the most recently added cause to be the only one set as proximal",
 		)
+
+		// And then it's time to edit a contributing cause and see that works
+		require.NoError(t, firstCause.Locator(`button.edit`).Click())
+		require.NoError(t, firstCause.Locator(`[name="why"]`).Fill("I want to say something else now"))
+		require.NoError(t, firstCause.Locator(`button.bind[type="submit"]`).Click())
+		require.NoError(t, assert.Locator(firstCause.Locator(".why")).ToContainText("I want to say something else now"))
 
 		require.NoError(t, pw.Stop(), "failed to stop playwright")
 	})


### PR DESCRIPTION
- **Allow for editing of bound contributing causes**
  And oh dear, so much boilerplate, I need to start cleaning up in the
  reviewing service tests because they're unwieldy. It's truly screaming
  that they're a mess.
  

- **Refactor service mock setup into a helper**
  