### PR TITLE
upgrade golangci lint to work with go     

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.62.2  # golangci-lint version
+          version: v1.64.6  # golangci-lint version

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 golang 1.24.0
 air 1.61.0
-golangci-lint 1.62.2
+golangci-lint 1.64.6

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-golang 1.23.3
+golang 1.24.0
 air 1.61.0
 golangci-lint 1.62.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gaqzi/incident-reviewer
 
-go 1.23.3
+go 1.24.0
 
 require (
 	github.com/donseba/go-htmx v1.12.0

--- a/script/sync-golangci-lint-version
+++ b/script/sync-golangci-lint-version
@@ -2,9 +2,9 @@
 # A script to help update the go version used across all the files that need
 # it set consistently, relies on asdf to manage the go version.
 
-: ${VERSION:=$1}
+: ${GOLANGCI_LINT_VERSION:=$1}
 
-if [ -z "$VERSION" ]; then
+if [ -z "$GOLANGCI_LINT_VERSION" ]; then
   GOLANGCI_LINT_VERSION="latest"
 fi
 


### PR DESCRIPTION
- **Upgrade to Go 1.24**
  

- **Correct the version variable name used**
  

- **Upgrade golangci-lint to work with Go 1.24**
  